### PR TITLE
Use XDG_PICTURES_DIR, add fallbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 anyhow = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
+directories = "6.0.0"
 env_logger = "0.11"
 hora = "0.1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ wayscrollshot -a fast        # FAST corner + HNSW index (experimental)
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-o, --output <PATH>` | Output file path | `~/Pictures/wayscrollshot-<timestamp>.png` |
+| `-o, --output <PATH>` | Output file path | `$XDG_PICTURES_DIR/wayscrollshot-<timestamp>.png` |
 | `-w, --preview-width <PX>` | Preview width in pixels | 280 |
 | `-c, --clipboard` | Copy to clipboard instead of saving | false |
 | `--no-preview` | Disable preview window | false |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ wayscrollshot -a fast        # FAST corner + HNSW index (experimental)
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-o, --output <PATH>` | Output file path | `$XDG_PICTURES_DIR/wayscrollshot-<timestamp>.png` |
+| `-o, --output <PATH>` | <p>Output file path<br><br>(falls back to ~/Pictures or current directory respectively if XDG_PICTURES_DIR isn't set.)</p> | `$XDG_PICTURES_DIR/wayscrollshot-<timestamp>.png` |
 | `-w, --preview-width <PX>` | Preview width in pixels | 280 |
 | `-c, --clipboard` | Copy to clipboard instead of saving | false |
 | `--no-preview` | Disable preview window | false |

--- a/README_CN.md
+++ b/README_CN.md
@@ -132,7 +132,7 @@ wayscrollshot -a fast        # FAST 角点 + HNSW 索引（实验性）
 
 | 选项 | 描述 | 默认值 |
 |------|------|--------|
-| `-o, --output <PATH>` | 输出文件路径 | `$XDG_PICTURES_DIR/wayscrollshot-<时间戳>.png` |
+| `-o, --output <PATH>` | <p>输出文件路径<br><br>( 若未设置 XDG_PICTURES_DIR，则分别回退至 ~/Pictures 或当前目录。)</p> | `$XDG_PICTURES_DIR/wayscrollshot-<时间戳>.png` |
 | `-w, --preview-width <PX>` | 预览宽度（像素） | 280 |
 | `-c, --clipboard` | 复制到剪贴板而非保存 | false |
 | `--no-preview` | 禁用预览窗口 | false |

--- a/README_CN.md
+++ b/README_CN.md
@@ -132,7 +132,7 @@ wayscrollshot -a fast        # FAST 角点 + HNSW 索引（实验性）
 
 | 选项 | 描述 | 默认值 |
 |------|------|--------|
-| `-o, --output <PATH>` | 输出文件路径 | `~/Pictures/wayscrollshot-<时间戳>.png` |
+| `-o, --output <PATH>` | 输出文件路径 | `$XDG_PICTURES_DIR/wayscrollshot-<时间戳>.png` |
 | `-w, --preview-width <PX>` | 预览宽度（像素） | 280 |
 | `-c, --clipboard` | 复制到剪贴板而非保存 | false |
 | `--no-preview` | 禁用预览窗口 | false |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,7 +21,7 @@ pub enum Algorithm {
 #[command(name = "wayscrollshot")]
 #[command(about = "A scrolling screenshot tool for Wayland", long_about = None)]
 pub struct Args {
-    /// Output file path (default: $XDG_PICTURES_DIR/wayscrollshot-<timestamp>.png)
+    /// Output file path (default: $XDG_PICTURES_DIR/wayscrollshot-<timestamp>.png falls back to ~/Pictures or current directory respectively if XDG_PICTURES_DIR isn't set.)
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,7 +21,7 @@ pub enum Algorithm {
 #[command(name = "wayscrollshot")]
 #[command(about = "A scrolling screenshot tool for Wayland", long_about = None)]
 pub struct Args {
-    /// Output file path (default: ~/Pictures/wayscrollshot-<timestamp>.png)
+    /// Output file path (default: $XDG_PICTURES_DIR/wayscrollshot-<timestamp>.png)
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -2,6 +2,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
+use std::fs;
 
 use anyhow::{bail, Context, Result};
 use chrono::Local;
@@ -92,10 +93,12 @@ fn default_output_dir() -> PathBuf {
         if let Some(pictures) = dirs.picture_dir() {
             return pictures.to_path_buf();
         }
-        return dirs.home_dir().to_path_buf();
+        let pictures_fallback = dirs.home_dir().join("Pictures");
+        if pictures_fallback.exists() || fs::create_dir_all(&pictures_fallback).is_ok() {
+            return pictures_fallback;
+        }
     }
-
-    // Both UserDirs and home_dir failed, fall back to current directory
+    // Both UserDirs and pictures_fallback failed, fall back to current directory
     std::env::current_dir()
         .unwrap_or_else(|_| PathBuf::from("."))
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Context, Result};
 use chrono::Local;
 use image::codecs::png::PngEncoder;
 use image::{ExtendedColorType, ImageEncoder, RgbaImage};
+use directories::UserDirs;
 
 pub fn save_image(image: Arc<RgbaImage>, output_path: Option<PathBuf>) -> Result<PathBuf> {
     let path = match output_path {
@@ -87,12 +88,14 @@ fn command_exists(cmd: &str) -> bool {
 }
 
 fn default_output_dir() -> PathBuf {
-    if let Some(home) = std::env::var_os("HOME") {
-        let pictures = PathBuf::from(&home).join("Pictures");
-        if pictures.is_dir() {
-            return pictures;
+    if let Some(dirs) = UserDirs::new() {
+        if let Some(pictures) = dirs.picture_dir() {
+            return pictures.to_path_buf();
         }
-        return PathBuf::from(home);
+        return dirs.home_dir().to_path_buf();
     }
-    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+
+    // Both UserDirs and home_dir failed, fall back to current directory
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
 }


### PR DESCRIPTION
This PR adds more robust directory handling and fallbacks. Previously saved files would default to ~/Pictures/wayscrollshot-<timestamp>.png. In this PR it now attempts to save the file in $XDG_PICTURES_DIR. If that fails, it will attempt to fall back to the user home directory, and if that fails it will output to the current directory.