### PR TITLE
feat: switch scrolling stitcher to OpenCV ORB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ hora = "0.1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 imageproc = "0.24"
 log = "0.4"
+opencv = { version = "0.98", default-features = false, features = ["clang-runtime", "calib3d", "features2d", "imgproc"] }
 rayon = "1.10"
 smithay-client-toolkit = "0.19"
 tiny-skia = "0.11"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ wayscrollshot -a fast        # FAST corner + HNSW index (experimental)
 | `-c, --clipboard` | Copy to clipboard instead of saving | false |
 | `--no-preview` | Disable preview window | false |
 | `--no-border` | Disable region border overlay | false |
-| `-a, --algorithm <ALG>` | Stitching algorithm: `col-sample`, `template`, `edge`, `fast` | col-sample |
+| `-a, --algorithm <ALG>` | Stitching algorithm: `opencv-orb`, `col-sample`, `template`, `edge`, `fast` | opencv-orb |
 
 ### Controls
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -137,7 +137,7 @@ wayscrollshot -a fast        # FAST 角点 + HNSW 索引（实验性）
 | `-c, --clipboard` | 复制到剪贴板而非保存 | false |
 | `--no-preview` | 禁用预览窗口 | false |
 | `--no-border` | 禁用区域边框覆盖层 | false |
-| `-a, --algorithm <ALG>` | 拼接算法：`col-sample`、`template`、`edge`、`fast` | col-sample |
+| `-a, --algorithm <ALG>` | 拼接算法：`opencv-orb`、`col-sample`、`template`、`edge`、`fast` | opencv-orb |
 
 ### 控制方式
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,7 +7,6 @@ use crate::constants::PREVIEW_MAX_WIDTH;
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 pub enum Algorithm {
     /// Column sampling (fast, good for most cases)
-    #[default]
     ColSample,
     /// Template matching (slower, more accurate)
     Template,
@@ -15,6 +14,10 @@ pub enum Algorithm {
     Edge,
     /// FAST corner + HNSW index (high accuracy, from snow-shot)
     Fast,
+    /// OpenCV ORB + brute-force matching + affine RANSAC
+    #[default]
+    #[value(name = "opencv-orb")]
+    OpenCvOrb,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -42,7 +45,7 @@ pub struct Args {
     pub no_border: bool,
 
     /// Stitching algorithm to use
-    #[arg(short, long, value_enum, default_value_t = Algorithm::ColSample)]
+    #[arg(short, long, value_enum, default_value_t = Algorithm::OpenCvOrb)]
     pub algorithm: Algorithm,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 mod capture;
 mod cli;
 mod constants;
-mod overlay;
 mod output;
+mod overlay;
 mod region_overlay;
 mod session;
 mod stitch;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,16 +1,23 @@
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use image::RgbaImage;
 
 use crate::capture::{capture_frame, select_region};
 use crate::cli::{Algorithm, Args};
-use crate::overlay::LayerShellOverlay;
 use crate::output::{copy_to_clipboard, save_image};
+use crate::overlay::LayerShellOverlay;
 use crate::region_overlay::RegionOverlay;
 use crate::stitch::{build_preview, MatchConfig, StitchOutcome, Stitcher};
 use crate::types::{Control, LayerMessage, Region, StitchState, UserCommand};
+
+const CAPTURE_INTERVAL: Duration = Duration::from_millis(45);
+const SIGNATURE_COLS: u32 = 18;
+const SIGNATURE_ROWS: u32 = 24;
+const DUPLICATE_AVG_DIFF: f32 = 1.1;
+const DUPLICATE_MAX_DIFF: u8 = 4;
 
 /// Runs one interactive capture session from region selection to final action.
 pub fn run(args: Args) -> Result<()> {
@@ -95,9 +102,7 @@ fn run_session(
                 }
             }
             UserCommand::Save => {
-                match take_snapshot(&state)
-                    .and_then(|img| save_image(img, args.output.clone()))
-                {
+                match take_snapshot(&state).and_then(|img| save_image(img, args.output.clone())) {
                     Ok(path) => {
                         log::info!("Saved to {}", path.display());
                         control.stop();
@@ -163,15 +168,27 @@ fn spawn_capture_worker(
     algorithm: Algorithm,
 ) -> thread::JoinHandle<()> {
     thread::spawn(move || {
-        let config = MatchConfig {
-            min_overlap: 100,
-            accept_diff: 5.0,
-            min_append: 15,
-            approx_diff: 1.0,
-            match_width: preview_width.max(200),
-            algorithm,
+        let config = match algorithm {
+            Algorithm::OpenCvOrb => MatchConfig {
+                min_overlap: 120,
+                accept_diff: 3.5,
+                min_append: 10,
+                approx_diff: 1.0,
+                match_width: preview_width.max(200),
+                algorithm,
+            },
+            _ => MatchConfig {
+                min_overlap: 100,
+                accept_diff: 5.0,
+                min_append: 15,
+                approx_diff: 1.0,
+                match_width: preview_width.max(200),
+                algorithm,
+            },
         };
         let mut stitcher = Stitcher::new(config);
+        let mut last_capture_end: Option<Instant> = None;
+        let mut last_signature: Option<Vec<u8>> = None;
 
         while control.is_running() {
             if control.is_paused() {
@@ -180,8 +197,32 @@ fn spawn_capture_worker(
                 continue;
             }
 
+            if let Some(last) = last_capture_end {
+                let elapsed = last.elapsed();
+                if elapsed < CAPTURE_INTERVAL {
+                    std::thread::sleep(CAPTURE_INTERVAL - elapsed);
+                }
+            }
+
             match capture_frame(&region) {
                 Ok(frame) => {
+                    last_capture_end = Some(Instant::now());
+
+                    let signature = frame_signature(&frame, SIGNATURE_COLS, SIGNATURE_ROWS);
+                    if let Some(previous) = last_signature.as_ref() {
+                        if is_duplicate_signature(previous, &signature) {
+                            update_status(
+                                &state,
+                                "Waiting for scroll".to_string(),
+                                Some(&stitcher),
+                                None,
+                                None,
+                            );
+                            continue;
+                        }
+                    }
+                    last_signature = Some(signature);
+
                     let outcome = stitcher.push_frame(frame);
                     match outcome {
                         StitchOutcome::FirstFrame => {
@@ -278,4 +319,43 @@ fn update_status(
     st.last_message = message;
     st.last_error = error;
     st.revision = st.revision.wrapping_add(1);
+}
+
+fn frame_signature(frame: &RgbaImage, cols: u32, rows: u32) -> Vec<u8> {
+    let width = frame.width().max(1);
+    let height = frame.height().max(1);
+    let cols = cols.max(1);
+    let rows = rows.max(1);
+    let mut signature = Vec::with_capacity((cols * rows) as usize);
+
+    for row in 0..rows {
+        let y = ((row * height) / rows).min(height - 1);
+        for col in 0..cols {
+            let x = ((col * width) / cols).min(width - 1);
+            let pixel = frame.get_pixel(x, y);
+            let gray =
+                (0.299 * pixel[0] as f32 + 0.587 * pixel[1] as f32 + 0.114 * pixel[2] as f32) as u8;
+            signature.push(gray);
+        }
+    }
+
+    signature
+}
+
+fn is_duplicate_signature(previous: &[u8], current: &[u8]) -> bool {
+    if previous.len() != current.len() || previous.is_empty() {
+        return false;
+    }
+
+    let mut sum = 0f32;
+    let mut max_diff = 0u8;
+
+    for (&a, &b) in previous.iter().zip(current.iter()) {
+        let diff = a.abs_diff(b);
+        max_diff = max_diff.max(diff);
+        sum += diff as f32;
+    }
+
+    let avg = sum / previous.len() as f32;
+    avg <= DUPLICATE_AVG_DIFF && max_diff <= DUPLICATE_MAX_DIFF
 }

--- a/src/stitch.rs
+++ b/src/stitch.rs
@@ -6,7 +6,12 @@ use hora::index::hnsw_idx::HNSWIndex;
 use hora::index::hnsw_params::HNSWParams;
 use image::imageops::{self, FilterType};
 use image::{GenericImage, GrayImage, RgbaImage};
-use imageproc::corners::{corners_fast9, corners_fast12, Corner};
+use imageproc::corners::{corners_fast12, corners_fast9, Corner};
+use opencv::calib3d;
+use opencv::core::{self, Point2f, Rect, Scalar, Vector, CV_8UC1, NORM_HAMMING};
+use opencv::features2d;
+use opencv::imgproc;
+use opencv::prelude::*;
 use rayon::prelude::*;
 
 use crate::cli::Algorithm;
@@ -21,6 +26,21 @@ const MIN_FAST_CORNERS: usize = 30;
 const STATIC_DIFF_THRESHOLD: u8 = 6;
 const DX_TOLERANCE: i32 = 2;
 const MIN_OFFSET_FILTER: i32 = 2;
+const ORB_MAX_FEATURES: i32 = 1500;
+const ORB_MIN_KEYPOINTS: usize = 80;
+const ORB_MIN_MATCHES: usize = 24;
+const ORB_MIN_INLIERS: usize = 18;
+const ORB_MAX_DX: f64 = 12.0;
+const ORB_MAX_GEOMETRY_DRIFT: f64 = 0.12;
+const ORB_TOP_IGNORE_RATIO: f32 = 0.12;
+const ORB_BOTTOM_IGNORE_RATIO: f32 = 0.08;
+const ORB_SIDE_IGNORE_RATIO: f32 = 0.04;
+const ORB_MIN_IGNORE_PX: u32 = 24;
+const TEMPLATE_MIN_HEIGHT: u32 = 48;
+const TEMPLATE_FALLBACK_MIN_SCORE: f32 = 0.72;
+const TEMPLATE_FALLBACK_MIN_MARGIN: f32 = 0.015;
+const TEMPLATE_VERIFY_MAX_DIFF: f32 = 18.0;
+const RELAXED_MIN_OVERLAP_FLOOR: u32 = 72;
 
 pub struct MatchConfig {
     pub min_overlap: u32,
@@ -183,6 +203,11 @@ pub enum StitchOutcome {
 
 type ColSamples = Vec<Vec<f32>>;
 
+struct OrbEstimate {
+    dy: f64,
+    confidence: f32,
+}
+
 impl Stitcher {
     pub fn new(config: MatchConfig) -> Self {
         Self {
@@ -218,6 +243,7 @@ impl Stitcher {
                     self.last_fast_index = Some(FastIndex::build(&gray));
                     self.last_fast_gray = Some(gray);
                 }
+                Algorithm::OpenCvOrb => {}
                 _ => {
                     self.last_cols = Some(self.compute_cols(&frame));
                 }
@@ -228,21 +254,27 @@ impl Stitcher {
         let (offset, confidence) = match self.config.algorithm {
             Algorithm::Fast => self.find_offset_fast(&frame),
             Algorithm::Template => self.find_offset_template(&frame),
+            Algorithm::OpenCvOrb => self.find_offset_opencv_orb(&frame),
             Algorithm::ColSample | Algorithm::Edge => self.find_offset_colsample(&frame),
         };
 
         log::debug!("Offset: {}, confidence: {}", offset, confidence);
+        let preserve_anchor = matches!(self.config.algorithm, Algorithm::OpenCvOrb);
 
         if confidence > self.config.accept_diff {
-            self.update_last_frame(frame);
+            if !preserve_anchor {
+                self.update_last_frame(frame);
+            }
             return StitchOutcome::NoMatch;
         }
 
         let new_height = if offset > 0 { offset as u32 } else { 0 };
 
         if new_height < self.config.min_append {
-            self.update_last_frame(frame);
-            self.last_offset = offset;
+            if !preserve_anchor {
+                self.update_last_frame(frame);
+                self.last_offset = offset;
+            }
             return StitchOutcome::NoProgress;
         }
 
@@ -275,6 +307,7 @@ impl Stitcher {
                 self.last_fast_index = Some(FastIndex::build(&gray));
                 self.last_fast_gray = Some(gray);
             }
+            Algorithm::OpenCvOrb => {}
             _ => {
                 self.last_cols = Some(self.compute_cols(&frame));
             }
@@ -370,7 +403,11 @@ impl Stitcher {
         // Confidence checks
         let min_matches = (curr_features.corners.len() as i32 / 10).max(3);
         if best_count < min_matches {
-            log::debug!("FAST: best_count {} < min_matches {}", best_count, min_matches);
+            log::debug!(
+                "FAST: best_count {} < min_matches {}",
+                best_count,
+                min_matches
+            );
             return (0, f32::MAX);
         }
 
@@ -457,13 +494,70 @@ impl Stitcher {
         (best_offset, diff * 10.0)
     }
 
+    fn find_offset_opencv_orb(&self, frame: &RgbaImage) -> (i32, f32) {
+        let prev = match &self.last_frame {
+            Some(f) => f,
+            None => return (0, f32::MAX),
+        };
+
+        match estimate_orb_offset(prev, frame, self.config.min_overlap) {
+            Ok(Some(estimate)) => (estimate.dy.round() as i32, estimate.confidence),
+            Ok(None) => {
+                if let Some((offset, confidence)) = self.find_offset_opencv_relaxed(prev, frame) {
+                    return (offset, confidence);
+                }
+                self.find_offset_template_fallback(prev, frame)
+            }
+            Err(err) => {
+                log::debug!("OpenCV ORB match failed: {err}");
+                if let Some((offset, confidence)) = self.find_offset_opencv_relaxed(prev, frame) {
+                    return (offset, confidence);
+                }
+                self.find_offset_template_fallback(prev, frame)
+            }
+        }
+    }
+
+    fn find_offset_opencv_relaxed(&self, prev: &RgbaImage, frame: &RgbaImage) -> Option<(i32, f32)> {
+        if self.config.min_overlap <= RELAXED_MIN_OVERLAP_FLOOR {
+            return None;
+        }
+
+        let relaxed_overlap = self
+            .config
+            .min_overlap
+            .saturating_sub(40)
+            .max(RELAXED_MIN_OVERLAP_FLOOR);
+
+        match estimate_orb_offset(prev, frame, relaxed_overlap) {
+            Ok(Some(estimate)) => {
+                let confidence = estimate.confidence + 0.45;
+                Some((estimate.dy.round() as i32, confidence))
+            }
+            Ok(None) => None,
+            Err(err) => {
+                log::debug!("Relaxed OpenCV ORB match failed: {err}");
+                None
+            }
+        }
+    }
+
+    fn find_offset_template_fallback(&self, prev: &RgbaImage, frame: &RgbaImage) -> (i32, f32) {
+        let Some((offset, confidence)) =
+            find_offset_template_content(prev, frame, self.last_offset, self.config.min_overlap)
+        else {
+            return self.find_offset_template(frame);
+        };
+        (offset, confidence)
+    }
+
     pub fn full_image(&self) -> Option<Arc<RgbaImage>> {
         self.full_image.clone()
     }
 
-pub fn stats(&self) -> StitchStats {
-    self.stats.clone()
-}
+    pub fn stats(&self) -> StitchStats {
+        self.stats.clone()
+    }
 }
 
 fn prepare_fast_gray(img: &RgbaImage, target_width: u32) -> GrayImage {
@@ -515,10 +609,277 @@ fn rgba_to_gray(img: &RgbaImage) -> GrayImage {
     })
 }
 
+fn estimate_orb_offset(
+    prev: &RgbaImage,
+    frame: &RgbaImage,
+    min_overlap: u32,
+) -> opencv::Result<Option<OrbEstimate>> {
+    if prev.width() != frame.width() || prev.height() != frame.height() {
+        return Ok(None);
+    }
+    if prev.width() < 80 || prev.height() < 120 {
+        return Ok(None);
+    }
+
+    let prev_gray = rgba_to_gray(prev);
+    let frame_gray = rgba_to_gray(frame);
+    let prev_mat = gray_to_mat(&prev_gray)?;
+    let frame_mat = gray_to_mat(&frame_gray)?;
+    let mask = build_feature_mask(prev.width(), prev.height())?;
+
+    let mut orb = features2d::ORB::create_def()?;
+    orb.set_max_features(ORB_MAX_FEATURES)?;
+
+    let mut prev_keypoints = Vector::<core::KeyPoint>::new();
+    let mut prev_descriptors = core::Mat::default();
+    orb.detect_and_compute_def(&prev_mat, &mask, &mut prev_keypoints, &mut prev_descriptors)?;
+
+    let mut curr_keypoints = Vector::<core::KeyPoint>::new();
+    let mut curr_descriptors = core::Mat::default();
+    orb.detect_and_compute_def(
+        &frame_mat,
+        &mask,
+        &mut curr_keypoints,
+        &mut curr_descriptors,
+    )?;
+
+    if prev_keypoints.len() < ORB_MIN_KEYPOINTS
+        || curr_keypoints.len() < ORB_MIN_KEYPOINTS
+        || prev_descriptors.empty()
+        || curr_descriptors.empty()
+    {
+        return Ok(None);
+    }
+
+    let matcher = features2d::BFMatcher::create(NORM_HAMMING, false)?;
+    let mut matches = Vector::<Vector<core::DMatch>>::new();
+    matcher.knn_train_match_def(&curr_descriptors, &prev_descriptors, &mut matches, 2)?;
+
+    let mut curr_points = Vector::<Point2f>::new();
+    let mut prev_points = Vector::<Point2f>::new();
+    let mut raw_matches = 0usize;
+
+    for pair in matches.iter() {
+        if pair.len() < 2 {
+            continue;
+        }
+
+        let best = pair.get(0)?;
+        let second = pair.get(1)?;
+
+        if best.distance >= second.distance * 0.78 {
+            continue;
+        }
+
+        let curr_pt = curr_keypoints.get(best.query_idx as usize)?.pt();
+        let prev_pt = prev_keypoints.get(best.train_idx as usize)?.pt();
+        let dx = (prev_pt.x - curr_pt.x) as f64;
+        let dy = (prev_pt.y - curr_pt.y) as f64;
+
+        if dy <= 1.0 || dx.abs() > ORB_MAX_DX * 2.0 {
+            continue;
+        }
+
+        curr_points.push(curr_pt);
+        prev_points.push(prev_pt);
+        raw_matches += 1;
+    }
+
+    if raw_matches < ORB_MIN_MATCHES {
+        return Ok(None);
+    }
+
+    let mut inliers = core::Mat::default();
+    let affine = calib3d::estimate_affine_partial_2d(
+        &curr_points,
+        &prev_points,
+        &mut inliers,
+        calib3d::RANSAC,
+        3.0,
+        2000,
+        0.99,
+        10,
+    )?;
+
+    if affine.empty() {
+        return Ok(None);
+    }
+
+    let a = *affine.at_2d::<f64>(0, 0)?;
+    let b = *affine.at_2d::<f64>(0, 1)?;
+    let c = *affine.at_2d::<f64>(1, 0)?;
+    let d = *affine.at_2d::<f64>(1, 1)?;
+    let tx = *affine.at_2d::<f64>(0, 2)?;
+    let ty = *affine.at_2d::<f64>(1, 2)?;
+
+    let scale = ((a * a + c * c).sqrt() + (b * b + d * d).sqrt()) * 0.5;
+    let geom_drift = (a - 1.0).abs() + (d - 1.0).abs() + b.abs() + c.abs();
+
+    if tx.abs() > ORB_MAX_DX
+        || ty <= 1.0
+        || ty >= (prev.height() - min_overlap) as f64
+        || (scale - 1.0).abs() > ORB_MAX_GEOMETRY_DRIFT
+        || geom_drift > ORB_MAX_GEOMETRY_DRIFT
+    {
+        return Ok(None);
+    }
+
+    let mut inlier_count = 0usize;
+    for row in 0..inliers.rows() {
+        if *inliers.at_2d::<u8>(row, 0)? != 0 {
+            inlier_count += 1;
+        }
+    }
+
+    if inlier_count < ORB_MIN_INLIERS {
+        return Ok(None);
+    }
+
+    let inlier_ratio = inlier_count as f32 / raw_matches as f32;
+    let confidence = (1.0 - inlier_ratio) * 3.5
+        + (tx.abs() as f32 / ORB_MAX_DX as f32)
+        + (geom_drift as f32 * 6.0);
+
+    Ok(Some(OrbEstimate { dy: ty, confidence }))
+}
+
+fn gray_to_mat(gray: &GrayImage) -> opencv::Result<core::Mat> {
+    let rows = gray.height() as i32;
+    let cols = gray.width() as i32;
+    let mut mat = core::Mat::new_rows_cols_with_default(rows, cols, CV_8UC1, Scalar::all(0.0))?;
+
+    for y in 0..rows {
+        for x in 0..cols {
+            *mat.at_2d_mut::<u8>(y, x)? = gray.get_pixel(x as u32, y as u32)[0];
+        }
+    }
+
+    Ok(mat)
+}
+
+fn build_feature_mask(width: u32, height: u32) -> opencv::Result<core::Mat> {
+    let mut mask = core::Mat::new_rows_cols_with_default(
+        height as i32,
+        width as i32,
+        CV_8UC1,
+        Scalar::all(0.0),
+    )?;
+
+    let side = ((width as f32 * ORB_SIDE_IGNORE_RATIO) as u32).max(ORB_MIN_IGNORE_PX);
+    let top = ((height as f32 * ORB_TOP_IGNORE_RATIO) as u32).max(ORB_MIN_IGNORE_PX);
+    let bottom = ((height as f32 * ORB_BOTTOM_IGNORE_RATIO) as u32).max(ORB_MIN_IGNORE_PX);
+    let roi_x = side.min(width.saturating_sub(1));
+    let roi_y = top.min(height.saturating_sub(1));
+    let roi_w = width.saturating_sub(roi_x.saturating_mul(2)).max(1);
+    let roi_h = height.saturating_sub(roi_y).saturating_sub(bottom).max(1);
+    let rect = Rect::new(roi_x as i32, roi_y as i32, roi_w as i32, roi_h as i32);
+
+    imgproc::rectangle(&mut mask, rect, Scalar::all(255.0), -1, imgproc::LINE_8, 0)?;
+
+    Ok(mask)
+}
+
+fn content_roi(width: u32, height: u32) -> (u32, u32, u32, u32) {
+    let side = ((width as f32 * ORB_SIDE_IGNORE_RATIO) as u32).max(ORB_MIN_IGNORE_PX);
+    let top = ((height as f32 * ORB_TOP_IGNORE_RATIO) as u32).max(ORB_MIN_IGNORE_PX);
+    let bottom = ((height as f32 * ORB_BOTTOM_IGNORE_RATIO) as u32).max(ORB_MIN_IGNORE_PX);
+    let x = side.min(width.saturating_sub(1));
+    let y = top.min(height.saturating_sub(1));
+    let roi_w = width.saturating_sub(x.saturating_mul(2)).max(1);
+    let roi_h = height.saturating_sub(y).saturating_sub(bottom).max(1);
+    (x, y, roi_w, roi_h)
+}
+
 fn to_grayscale_vec(img: &RgbaImage) -> Vec<f32> {
     img.pixels()
         .map(|p| 0.299 * p[0] as f32 + 0.587 * p[1] as f32 + 0.114 * p[2] as f32)
         .collect()
+}
+
+fn find_offset_template_content(
+    prev: &RgbaImage,
+    frame: &RgbaImage,
+    predict: i32,
+    min_overlap: u32,
+) -> Option<(i32, f32)> {
+    if prev.width() != frame.width() || prev.height() != frame.height() {
+        return None;
+    }
+
+    let width = prev.width();
+    let height = prev.height();
+    let (roi_x, roi_y, roi_w, roi_h) = content_roi(width, height);
+    if roi_h < TEMPLATE_MIN_HEIGHT * 2 || roi_w < 40 {
+        return None;
+    }
+
+    let template_h = (roi_h / 3).max(TEMPLATE_MIN_HEIGHT).min(roi_h - 1);
+    let search_start = roi_y as i32;
+    let search_end = (roi_y + roi_h - template_h) as i32;
+    if search_end <= search_start {
+        return None;
+    }
+
+    let prev_gray = to_grayscale_vec(prev);
+    let frame_gray = to_grayscale_vec(frame);
+    let frame_template_y = roi_y;
+
+    let mut best_offset = 0i32;
+    let mut best_score = f32::MIN;
+    let mut second_score = f32::MIN;
+
+    let max_offset = (height as i32 - min_overlap as i32).max(0);
+    let predict = predict.clamp(0, max_offset.min(search_end - search_start));
+    for offset in predict_offset_iter(search_end - search_start, predict) {
+        let search_y = search_start + offset;
+        if search_y < 0 || search_y + template_h as i32 > height as i32 {
+            continue;
+        }
+
+        let score = ncc_score_region(
+            &prev_gray,
+            &frame_gray,
+            width,
+            roi_x,
+            roi_w,
+            search_y as u32,
+            frame_template_y,
+            template_h,
+        );
+
+        if score > best_score {
+            second_score = best_score;
+            best_score = score;
+            best_offset = offset;
+        } else if score > second_score {
+            second_score = score;
+        }
+    }
+
+    if best_score < TEMPLATE_FALLBACK_MIN_SCORE {
+        return None;
+    }
+
+    if second_score.is_finite() && best_score - second_score < TEMPLATE_FALLBACK_MIN_MARGIN {
+        return None;
+    }
+
+    let verification = overlap_mean_abs_diff(
+        &prev_gray,
+        &frame_gray,
+        width,
+        roi_x,
+        roi_w,
+        best_offset as u32,
+        height.saturating_sub(best_offset as u32),
+    );
+
+    if !verification.is_finite() || verification > TEMPLATE_VERIFY_MAX_DIFF {
+        return None;
+    }
+
+    let confidence = (1.0 - best_score.max(0.0)) * 8.0 + verification / 10.0;
+    Some((best_offset, confidence))
 }
 
 fn ncc_score(image_gray: &[f32], template_gray: &[f32], y_offset: u32, width: u32) -> f32 {
@@ -572,6 +933,98 @@ fn ncc_score(image_gray: &[f32], template_gray: &[f32], y_offset: u32, width: u3
     ncc / (tmpl_len as f32 * tmpl_std * img_std)
 }
 
+fn ncc_score_region(
+    image_gray: &[f32],
+    template_gray: &[f32],
+    width: u32,
+    roi_x: u32,
+    roi_w: u32,
+    image_y: u32,
+    template_y: u32,
+    template_h: u32,
+) -> f32 {
+    if roi_w == 0 || template_h == 0 || width == 0 {
+        return f32::MIN;
+    }
+
+    let mut tmpl_sum = 0.0f32;
+    let mut img_sum = 0.0f32;
+    let mut count = 0usize;
+
+    for row in 0..template_h {
+        let tmpl_base = ((template_y + row) * width + roi_x) as usize;
+        let img_base = ((image_y + row) * width + roi_x) as usize;
+        for col in 0..roi_w as usize {
+            tmpl_sum += template_gray[tmpl_base + col];
+            img_sum += image_gray[img_base + col];
+            count += 1;
+        }
+    }
+
+    if count == 0 {
+        return f32::MIN;
+    }
+
+    let tmpl_mean = tmpl_sum / count as f32;
+    let img_mean = img_sum / count as f32;
+    let mut numerator = 0.0f32;
+    let mut tmpl_var = 0.0f32;
+    let mut img_var = 0.0f32;
+
+    for row in 0..template_h {
+        let tmpl_base = ((template_y + row) * width + roi_x) as usize;
+        let img_base = ((image_y + row) * width + roi_x) as usize;
+        for col in 0..roi_w as usize {
+            let tmpl = template_gray[tmpl_base + col] - tmpl_mean;
+            let img = image_gray[img_base + col] - img_mean;
+            numerator += tmpl * img;
+            tmpl_var += tmpl * tmpl;
+            img_var += img * img;
+        }
+    }
+
+    if tmpl_var <= 1.0 || img_var <= 1.0 {
+        return f32::MIN;
+    }
+
+    numerator / (tmpl_var.sqrt() * img_var.sqrt())
+}
+
+fn overlap_mean_abs_diff(
+    prev_gray: &[f32],
+    frame_gray: &[f32],
+    width: u32,
+    roi_x: u32,
+    roi_w: u32,
+    offset: u32,
+    overlap_h: u32,
+) -> f32 {
+    if roi_w == 0 || overlap_h == 0 {
+        return f32::MAX;
+    }
+
+    let sample_h = overlap_h.min(160);
+    let start_prev_y = offset + overlap_h.saturating_sub(sample_h);
+    let start_frame_y = overlap_h.saturating_sub(sample_h);
+    let mut sum = 0.0f32;
+    let mut count = 0usize;
+
+    for row in 0..sample_h {
+        let prev_base = ((start_prev_y + row) * width + roi_x) as usize;
+        let frame_base = ((start_frame_y + row) * width + roi_x) as usize;
+        for col in 0..roi_w as usize {
+            sum += (prev_gray[prev_base + col] - frame_gray[frame_base + col]).abs();
+            count += 1;
+        }
+    }
+
+    if count == 0 {
+        return f32::MAX;
+    }
+
+    sum / count as f32
+}
+
 pub fn build_preview(image: &RgbaImage, fixed_width: u32) -> PreviewImage {
     let width = image.width();
     let height = image.height();
@@ -609,9 +1062,8 @@ fn col_sampling(img: &RgbaImage) -> ColSamples {
             for &x in cols {
                 if x < w {
                     let pixel = img.get_pixel(x as u32, y as u32);
-                    let gray = 0.299 * pixel[0] as f32
-                        + 0.587 * pixel[1] as f32
-                        + 0.114 * pixel[2] as f32;
+                    let gray =
+                        0.299 * pixel[0] as f32 + 0.587 * pixel[1] as f32 + 0.114 * pixel[2] as f32;
                     sum += gray;
                     count += 1;
                 }
@@ -778,12 +1230,10 @@ fn col_sampling_edge(img: &RgbaImage) -> ColSamples {
                     let curr = img.get_pixel(x as u32, y as u32);
                     let prev = img.get_pixel(x as u32, (y - 1) as u32);
 
-                    let gray_curr = 0.299 * curr[0] as f32
-                        + 0.587 * curr[1] as f32
-                        + 0.114 * curr[2] as f32;
-                    let gray_prev = 0.299 * prev[0] as f32
-                        + 0.587 * prev[1] as f32
-                        + 0.114 * prev[2] as f32;
+                    let gray_curr =
+                        0.299 * curr[0] as f32 + 0.587 * curr[1] as f32 + 0.114 * curr[2] as f32;
+                    let gray_prev =
+                        0.299 * prev[0] as f32 + 0.587 * prev[1] as f32 + 0.114 * prev[2] as f32;
 
                     let edge = (gray_curr - gray_prev).abs();
                     sum += edge;
@@ -798,4 +1248,178 @@ fn col_sampling_edge(img: &RgbaImage) -> ColSamples {
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{imageops, Rgba};
+
+    fn make_scroll_canvas(width: u32, height: u32) -> RgbaImage {
+        let mut img = RgbaImage::from_pixel(width, height, Rgba([245, 245, 245, 255]));
+
+        for y in (0..height).step_by(36) {
+            let accent = ((y / 3) % 180) as u8;
+            for x in 24..width.saturating_sub(24) {
+                let stripe = if (x / 7 + y / 11) % 2 == 0 { 220 } else { 180 };
+                img.put_pixel(x, y, Rgba([accent, stripe, 80, 255]));
+                if y + 1 < height {
+                    img.put_pixel(x, y + 1, Rgba([30, 30, 30, 255]));
+                }
+            }
+        }
+
+        for block in 0..10 {
+            let y0 = 30 + block * 80;
+            let block_h = 34 + (block % 3) * 8;
+            let color = [
+                ((40u16 + block as u16 * 17) % 200) as u8,
+                ((90u16 + block as u16 * 11) % 200) as u8,
+                ((140u16 + block as u16 * 19) % 200) as u8,
+                255,
+            ];
+            for y in y0..(y0 + block_h).min(height) {
+                for x in 30..width.saturating_sub(30) {
+                    if x % (9 + block as u32 % 5) == 0 || y % (7 + block as u32 % 4) == 0 {
+                        img.put_pixel(x, y, Rgba(color));
+                    }
+                }
+            }
+        }
+
+        for col in [42, 96, 154, 211, 268] {
+            if col >= width {
+                continue;
+            }
+            for y in 20..height.saturating_sub(20) {
+                if (y / 13) % 3 != 0 {
+                    img.put_pixel(col, y, Rgba([20, 20, 20, 255]));
+                }
+            }
+        }
+
+        img
+    }
+
+    fn crop_frame(canvas: &RgbaImage, y: u32, height: u32) -> RgbaImage {
+        imageops::crop_imm(canvas, 0, y, canvas.width(), height).to_image()
+    }
+
+    fn make_line_canvas(width: u32, height: u32) -> RgbaImage {
+        let mut img = RgbaImage::from_pixel(width, height, Rgba([250, 250, 250, 255]));
+        let mut y = 16u32;
+        let mut band = 0u32;
+
+        while y < height.saturating_sub(16) {
+            let band_h = 6 + (band % 5) * 4;
+            let gray = (40 + ((band * 29) % 160)) as u8;
+            for yy in y..(y + band_h).min(height) {
+                for x in 28..width.saturating_sub(28) {
+                    img.put_pixel(x, yy, Rgba([gray, gray, gray, 255]));
+                }
+            }
+            y += band_h + 9 + (band % 4) * 3;
+            band += 1;
+        }
+
+        img
+    }
+
+    #[test]
+    fn opencv_orb_estimates_vertical_offset() {
+        let canvas = make_scroll_canvas(320, 1000);
+        let first = crop_frame(&canvas, 0, 320);
+        let second = crop_frame(&canvas, 84, 320);
+
+        let estimate = estimate_orb_offset(&first, &second, 120)
+            .expect("opencv estimate")
+            .expect("orb match");
+
+        assert!((estimate.dy - 84.0).abs() <= 4.0, "dy={}", estimate.dy);
+        assert!(
+            estimate.confidence < 3.5,
+            "confidence={}",
+            estimate.confidence
+        );
+    }
+
+    #[test]
+    fn opencv_orb_keeps_anchor_after_bad_frame() {
+        let canvas = make_scroll_canvas(320, 1000);
+        let first = crop_frame(&canvas, 0, 320);
+        let shifted = crop_frame(&canvas, 96, 320);
+        let bad = RgbaImage::from_pixel(320, 320, Rgba([255, 255, 255, 255]));
+
+        let mut stitcher = Stitcher::new(MatchConfig {
+            min_overlap: 120,
+            accept_diff: 3.5,
+            min_append: 10,
+            approx_diff: 1.0,
+            algorithm: Algorithm::OpenCvOrb,
+            match_width: 320,
+        });
+
+        assert!(matches!(
+            stitcher.push_frame(first),
+            StitchOutcome::FirstFrame
+        ));
+        assert!(matches!(stitcher.push_frame(bad), StitchOutcome::NoMatch));
+
+        match stitcher.push_frame(shifted) {
+            StitchOutcome::Appended { added } => assert!(added >= 92 && added <= 100, "{added}"),
+            _ => panic!("expected appended after bad frame"),
+        }
+    }
+
+    #[test]
+    fn opencv_orb_falls_back_to_template_on_low_feature_frames() {
+        let canvas = make_line_canvas(320, 1000);
+        let first = crop_frame(&canvas, 0, 320);
+        let second = crop_frame(&canvas, 72, 320);
+
+        let mut stitcher = Stitcher::new(MatchConfig {
+            min_overlap: 120,
+            accept_diff: 3.5,
+            min_append: 10,
+            approx_diff: 1.0,
+            algorithm: Algorithm::OpenCvOrb,
+            match_width: 320,
+        });
+
+        assert!(matches!(
+            stitcher.push_frame(first),
+            StitchOutcome::FirstFrame
+        ));
+
+        match stitcher.push_frame(second) {
+            StitchOutcome::Appended { added } => assert!(added >= 68 && added <= 76, "{added}"),
+            _ => panic!("expected appended via template fallback"),
+        }
+    }
+
+    #[test]
+    fn opencv_orb_relaxed_overlap_handles_large_jump() {
+        let canvas = make_scroll_canvas(320, 1200);
+        let first = crop_frame(&canvas, 0, 320);
+        let second = crop_frame(&canvas, 208, 320);
+
+        let mut stitcher = Stitcher::new(MatchConfig {
+            min_overlap: 120,
+            accept_diff: 3.5,
+            min_append: 10,
+            approx_diff: 1.0,
+            algorithm: Algorithm::OpenCvOrb,
+            match_width: 320,
+        });
+
+        assert!(matches!(
+            stitcher.push_frame(first),
+            StitchOutcome::FirstFrame
+        ));
+
+        match stitcher.push_frame(second) {
+            StitchOutcome::Appended { added } => assert!(added >= 202 && added <= 214, "{added}"),
+            _ => panic!("expected appended via relaxed overlap"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- replace the default scrolling stitcher with an OpenCV ORB + RANSAC pipeline
- add capture throttling and duplicate-frame filtering to reduce mid-scroll stalls
- add template and relaxed-overlap fallbacks plus regression coverage for large jumps and low-feature pages

## Testing
- cargo test
